### PR TITLE
fix: call env.stop() on finish

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -23,8 +23,8 @@ pub trait Environment {
     /// And the config file's path to this environment if it's find, it's defined
     /// by the `env_config_file` field in the root config toml, and the default
     /// value is `config.toml`.
-    async fn start(&self, mode: &str, config: Option<String>) -> Self::DB;
+    async fn start(&self, env: &str, config: Option<String>) -> Self::DB;
 
     /// Stop one [`Database`].
-    async fn stop(&self, mode: &str, database: Self::DB);
+    async fn stop(&self, env: &str, database: Self::DB);
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -124,6 +124,9 @@ impl<E: Environment> Runner<E> {
             start.elapsed().as_millis()
         );
 
+        // stop this env
+        self.env.stop(&env, db).await;
+
         if !diff_cases.is_empty() {
             println!("Different cases:");
             println!("{:#?}", diff_cases);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -30,7 +30,7 @@ use crate::{config::Config, environment::Environment};
 /// For more detailed explaination, refer to crate level documentment.
 pub struct Runner<E: Environment> {
     config: Config,
-    env: Arc<E>,
+    env_controller: Arc<E>,
 }
 
 impl<E: Environment> Runner<E> {
@@ -53,14 +53,14 @@ impl<E: Environment> Runner<E> {
 
         Ok(Self {
             config,
-            env: Arc::new(env),
+            env_controller: Arc::new(env),
         })
     }
 
     pub async fn new_with_config(config: Config, env: E) -> Result<Self> {
         Ok(Self {
             config,
-            env: Arc::new(env),
+            env_controller: Arc::new(env),
         })
     }
 
@@ -68,11 +68,11 @@ impl<E: Environment> Runner<E> {
         let environments = self.collect_env().await?;
         for env in environments {
             // todo: read env config
-            let db = self.env.start(&env, None).await;
+            let db = self.env_controller.start(&env, None).await;
             if let Err(e) = self.run_env(&env, &db).await {
                 println!("Environment {} run failed with error {:?}", env, e);
             }
-            self.env.stop(&env, db).await;
+            self.env_controller.stop(&env, db).await;
         }
 
         Ok(())


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

## Changes Included

I forgot to call `stop()` on one env run finished. It may leave the started test target running and fail the next run. This patch fixes it.