### PR TITLE
feat: add support for filtering test cases

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,4 +27,7 @@ pub struct Config {
     /// Fail this run as soon as one case fails if true
     #[builder(default = "true")]
     pub fail_fast: bool,
+    /// If specified, only run cases containing this string in their names.
+    #[builder(default = "String::new()")]
+    pub test_filter: String,
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -86,8 +86,8 @@ impl<E: Environment> Runner<E> {
 
         while let Some(dir) = dirs.next_entry().await? {
             if dir.file_type().await?.is_dir() {
-                let file_name = dir.file_name();
-                result.push(file_name.to_str().unwrap().to_owned());
+                let file_name = dir.file_name().to_str().unwrap().to_string();
+                result.push(file_name);
             }
         }
 
@@ -182,6 +182,13 @@ impl<E: Environment> Runner<E> {
                     })
             })
             .map(|path| path.with_extension(""))
+            .filter(|path| {
+                path.file_name()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default()
+                    .contains(&self.config.test_filter)
+            })
             .collect();
 
         // sort the cases in an os-independent order.


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

Closes #

# Rationale for this change

Provide the ability to filter on test cases. This is useful when you only want to debug a few sets of specific test cases.

# What changes are included in this PR?

Add new options field `test_filter`. Default to an empty string (`String::new()`) which is contained in all other strings.

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

Yes, API changed. New options field is added.

# How does this change test

untested