### PR TITLE
fix: disable prettydiff output which will seg fault

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "SQL integration test harness"
 [dependencies]
 async-trait = "0.1"
 derive_builder = "0.11"
-prettydiff = { version = "0.6", features = ["prettytable-rs"] }
+prettydiff = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -237,8 +237,16 @@ impl<E: Environment> Runner<E> {
             .names("Expected", "Actual");
         let is_different = diff.diff().iter().any(|d| !matches!(d, DiffOp::Equal(_)));
         if is_different {
-            println!("Result unexpected, path:{:?}\n", path.as_ref());
-            diff.prettytable();
+            println!("Result unexpected, path:{:?}", path.as_ref());
+            println!(
+                "Hint: compare them with \"diff {} {}\"\n",
+                path.as_ref()
+                    .with_extension(&self.config.output_result_extension)
+                    .display(),
+                path.as_ref()
+                    .with_extension(&self.config.expect_result_extension)
+                    .display()
+            )
         }
 
         Ok(is_different)


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

Closes #

# Rationale for this change
 
the `prettytable` will lead to a seg fault in my env
```
Process 58035 stopped
* thread #1, name = 'main', queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x252400002524)
    frame #0: 0x00000001004aa154 sqlness-runner`prettytable::cell::Cell::get_hspan::hedf898adffacb284(self=0x000025240000251c) at cell.rs:198:9
   195 
   196      /// Get horizontal span of this cell (> 0)
   197      pub fn get_hspan(&self) -> usize {
-> 198          self.hspan
   199      }
   200 
   201      /// Return a copy of the full string contained in the cell
Target 0: (sqlness-runner) stopped.
(lldb) bt
error: need to add support for DW_TAG_base_type '()' encoded with DW_ATE = 0x7, bit_size = 0
* thread #1, name = 'main', queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x252400002524)
  * frame #0: 0x00000001004aa154 sqlness-runner`prettytable::cell::Cell::get_hspan::hedf898adffacb284(self=0x000025240000251c) at cell.rs:198:9
    frame #1: 0x00000001004a7664 sqlness-runner`prettytable::row::Row::column_count::_$u7b$$u7b$closure$u7d$$u7d$::h6a59469819e3a6c9((null)=0x000000016fdf5fd7, c=0x000025240000251c) at row.rs:36:35
    frame #2: 0x00000001004a3e44 sqlness-runner`core::iter::adapters::map::map_fold::_$u7b$$u7b$closure$u7d$$u7d$::h2e0cffeb9a3436fa(acc=0, elt=0x000025240000251c) at map.rs:84:28
    frame #3: 0x00000001004a6328 sqlness-runner`core::iter::traits::iterator::Iterator::fold::h8f190637abd013bf(self=Iter<prettytable::cell::Cell> @ 0x000000016fdf5fc0, init=0, f=(g = core::iter::traits::accum::{impl#48}::sum::{closure_env#0}<> @ 0x000000016fdf5fd7, f = prettytable::row::{impl#0}::column_count::{closure_env#0} @ 0x000000016fdf5fd7)) at iterator.rs:2415:21
    frame #4: 0x00000001004a3ad4 sqlness-runner`_$LT$core..iter..adapters..map..Map$LT$I$C$F$GT$$u20$as$u20$core..iter..traits..iterator..Iterator$GT$::fold::hc508c78e2663bace(self=Map<core::slice::iter::Iter<prettytable::cell::Cell>, prettytable::row::{impl#0}::column_count::{closure_env#0}> @ 0x000000016fdf6060, init=0, g={closure_env#0}<core::iter::adapters::map::Map<core::slice::iter::Iter<prettytable::cell::Cell>, prettytable::row::{impl#0}::column_count::{closure_env#0}>> @ 0x000000016fdf607f) at map.rs:124:9
    frame #5: 0x00000001004a9d38 sqlness-runner`_$LT$usize$u20$as$u20$core..iter..traits..accum..Sum$GT$::sum::h79670482bb6bec17(iter=Map<core::slice::iter::Iter<prettytable::cell::Cell>, prettytable::row::{impl#0}::column_count::{closure_env#0}> @ 0x000000016fdf60a0) at accum.rs:50:17
    frame #6: 0x00000001004a3d04 sqlness-runner`core::iter::traits::iterator::Iterator::sum::h70a201ec1e976ff7(self=Map<core::slice::iter::Iter<prettytable::cell::Cell>, prettytable::row::{impl#0}::column_count::{closure_env#0}> @ 0x000000016fdf60c0) at iterator.rs:3382:9
    frame #7: 0x00000001004a7634 sqlness-runner`prettytable::row::Row::column_count::he334ed0a6e16b4e5(self=0x0000000101a09280) at row.rs:36:9
    frame #8: 0x000000010049f948 sqlness-runner`prettytable::TableSlice::get_column_num::hde7a60961efdc884(self=0x000000016fdf6928) at lib.rs:76:21
    frame #9: 0x000000010049faa4 sqlness-runner`prettytable::TableSlice::get_all_column_width::hf48493e04c4f43c1(self=0x000000016fdf6928) at lib.rs:118:22
    frame #10: 0x000000010049fbf4 sqlness-runner`prettytable::TableSlice::__print::h0ae9ac44bceead8e(self=0x000000016fdf6928, out=&mut (dyn term::Terminal<Output=std::io::stdio::Stdout> + core::marker::Send) @ 0x000000016fdf64f0, f=0x000000000000009b) at lib.rs:143:25
    frame #11: 0x00000001004a0d2c sqlness-runner`prettytable::TableSlice::print_term::h50e3f76c7992b184(self=0x000000016fdf6928, out=&mut (dyn term::Terminal<Output=std::io::stdio::Stdout> + core::marker::Send) @ 0x000000016fdf65c0) at lib.rs:175:9
    frame #12: 0x00000001004a0e64 sqlness-runner`prettytable::TableSlice::print_tty::h4aa7cf828f3b69c8(self=0x000000016fdf6928, force_colorize=false) at lib.rs:190:36
    frame #13: 0x00000001004a106c sqlness-runner`prettytable::TableSlice::printstd::h46a1a85bb102af17(self=0x000000016fdf6928) at lib.rs:209:9
    frame #14: 0x00000001004a13e8 sqlness-runner`prettytable::Table::printstd::ha46a2bc70b6ac9f9(self=0x000000016fdf6928) at lib.rs:376:9
    frame #15: 0x0000000100493844 sqlness-runner`prettydiff::text::LineChangeset::prettytable::h76162d85165bf1a9(self=0x000000016fdf7c90) at text.rs:389:9
    frame #16: 0x0000000100082928 sqlness-runner`sqlness::runner::Runner$LT$E$GT$::compare::_$u7b$$u7b$closure$u7d$$u7d$::hfdd7d0665feea2ca((null)=0x000000016fdfc050) at runner.rs:241:13
    frame #17: 0x000000010008021c sqlness-runner`sqlness::runner::Runner$LT$E$GT$::run_single_case::_$u7b$$u7b$closure$u7d$$u7d$::hefbd6549868525ed((null)=0x000000016fdfc050) at runner.rs:155:47
    frame #18: 0x0000000100082fd8 sqlness-runner`sqlness::runner::Runner$LT$E$GT$::run_env::_$u7b$$u7b$closure$u7d$$u7d$::hcc93ff2b242ebe15((null)=0x000000016fdfc050) at runner.rs:103:62
    frame #19: 0x000000010008180c sqlness-runner`sqlness::runner::Runner$LT$E$GT$::run::_$u7b$$u7b$closure$u7d$$u7d$::hd62f13a5cebe1792((null)=0x000000016fdfc050) at runner.rs:74:52
    frame #20: 0x0000000100036acc sqlness-runner`sqlness_runner::main::_$u7b$$u7b$closure$u7d$$u7d$::hba94778f7967cbb3((null)=0x000000016fdfc050) at main.rs:28:17
    frame #21: 0x000000010004cc08 sqlness-runner`tokio::runtime::park::CachedParkThread::block_on::_$u7b$$u7b$closure$u7d$$u7d$::h0fcf3db69bf850fb at park.rs:283:63
    frame #22: 0x000000010004c6dc sqlness-runner`tokio::runtime::park::CachedParkThread::block_on::h9d0fc911c31aaa95 at coop.rs:102:5
    frame #23: 0x000000010004c678 sqlness-runner`tokio::runtime::park::CachedParkThread::block_on::h9d0fc911c31aaa95 [inlined] tokio::runtime::coop::budget::h7e71e02b61a1b864(f={closure_env#0}<sqlness_runner::main::{async_block_env#0}> @ 0x000000016fdfc608) at coop.rs:68:5
    frame #24: 0x000000010004c5fc sqlness-runner`tokio::runtime::park::CachedParkThread::block_on::h9d0fc911c31aaa95(self=0x000000016fdfc6af, f={async_block_env#0} @ 0x000000016fdfc6b0) at park.rs:283:31
    frame #25: 0x000000010003515c sqlness-runner`tokio::runtime::context::BlockingRegionGuard::block_on::hed2623b59a9e50b8(self=0x000000016fdfcc48, f={async_block_env#0} @ 0x000000016fdfcc68) at context.rs:295:13
    frame #26: 0x000000010004be44 sqlness-runner`tokio::runtime::scheduler::multi_thread::MultiThread::block_on::h4597f91a25863ba6(self=0x000000016fdfe7d0, handle=0x000000016fdfe7f8, future={async_block_env#0} @ 0x000000016fdfd790) at mod.rs:66:9
    frame #27: 0x000000010007dd30 sqlness-runner`tokio::runtime::runtime::Runtime::block_on::hb77f1895920fa05b(self=0x000000016fdfe7b8, future={async_block_env#0} @ 0x000000016fdfe908) at runtime.rs:284:45
    frame #28: 0x000000010007db98 sqlness-runner`sqlness_runner::main::hafacaf859cead7ee at main.rs:28:5
```



# What changes are included in this PR?

Haven't found out the reason. Disable it for now, display a diff command hint instead.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
