### PR TITLE
refactor: rename Environment to EnvController

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,7 +3,7 @@
 use std::{env, fmt::Display, process};
 
 use async_trait::async_trait;
-use sqlness::{Database, Environment, Runner, SqlnessError};
+use sqlness::{Database, EnvController, Runner, SqlnessError};
 
 struct MyEnv;
 struct MyDB;
@@ -28,7 +28,7 @@ impl MyDB {
 }
 
 #[async_trait]
-impl Environment for MyEnv {
+impl EnvController for MyEnv {
     type DB = MyDB;
 
     async fn start(&self, env: &str, config: Option<String>) -> Self::DB {

--- a/src/database.rs
+++ b/src/database.rs
@@ -6,11 +6,11 @@ use async_trait::async_trait;
 
 /// Query executor.
 ///
-/// [`Runner`] will call [`Environment::start`] to create database to
+/// [`Runner`] will call [`EnvController::start`] to create database to
 /// execute query.
 ///
 /// [`Runner`]: crate::Runner
-/// [`Environment::start`]: crate::Environment#tymethod.start
+/// [`EnvController::start`]: crate::EnvController#tymethod.start
 #[async_trait]
 pub trait Database {
     async fn query(&self, query: String) -> Box<dyn Display>;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 
 use crate::database::Database;
 
-/// Test environment definition.
+/// Controller of test environments.
 ///
 /// Different environments usually stands for different start or deploy manner,
-/// like standalone versus cluster etc. [`Environment`] is sort of [`Database`]
+/// like standalone versus cluster etc. [`EnvController`] is sort of [`Database`]
 /// "factory" - it create different [`Database`]s with different environment
 /// mode parameter.
 ///
@@ -16,7 +16,7 @@ use crate::database::Database;
 /// directory name. Refer to crate level documentation for more information
 /// about directory organizaiton rules.
 #[async_trait]
-pub trait Environment {
+pub trait EnvController {
     type DB: Database;
 
     /// Start a [`Database`] to run test queries.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! compare the result. There are three things you need to do to complete an
 //! integration test:
 //! - Prepare the test case (of course!)
-//! - Implement [`Environment`] and [`Database`]. They provide methods to start
+//! - Implement [`EnvController`] and [`Database`]. They provide methods to start
 //!   the server, submit the query and clean up etc.
 //! - Format the result. Implement [`Display`] for your query result to make them
 //!   comparable.
@@ -44,7 +44,7 @@
 //! ```
 //!
 //! Here the root dir is `sqlness`, it contains two sub-directories for different
-//! [`Environment`]s `local` and `remote`. Each environment has an env-specific
+//! "environments": `local` and `remote`. Each environment has an env-specific
 //! configuration `config.toml`. All the test cases are placed under corresponding
 //! environment directory.
 //!
@@ -62,6 +62,6 @@ mod runner;
 
 pub use config::{Config, ConfigBuilder};
 pub use database::Database;
-pub use environment::Environment;
+pub use environment::EnvController;
 pub use error::SqlnessError;
 pub use runner::Runner;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -13,7 +13,7 @@ use walkdir::WalkDir;
 
 use crate::case::TestCase;
 use crate::error::{Result, SqlnessError};
-use crate::{config::Config, environment::Environment};
+use crate::{config::Config, environment::EnvController};
 
 /// The entrypoint of this crate.
 ///
@@ -30,12 +30,12 @@ use crate::{config::Config, environment::Environment};
 /// ```
 ///
 /// For more detailed explaination, refer to crate level documentment.
-pub struct Runner<E: Environment> {
+pub struct Runner<E: EnvController> {
     config: Config,
     env_controller: Arc<E>,
 }
 
-impl<E: Environment> Runner<E> {
+impl<E: EnvController> Runner<E> {
     pub async fn new<P: AsRef<Path>>(config_path: P, env: E) -> Result<Self> {
         let mut config_file =
             File::open(config_path.as_ref())


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

Closes #

# Rationale for this change
 
As discussed with @jiacai2050, `Environment` is not a good name. It's actual the controller of environments:
>`EnvController` is sort of `Database` "factory" - it create different `Database`s with different environment mode parameter.
 

# What changes are included in this PR?

Rename `Environment` to `EnvController` to better reflect what it is.

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

Yes. This is an API change.

# How does this change test

no need
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
