### PR TITLE
fix: return correct exit code when one env failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,11 @@ jobs:
         run: |
           if make bad-example; then
             echo "Cannot reach here, this example should fail"
-            exit 1;
+            exit 1
           else
             echo "Expected, this example should fail"
-            exit 0;
-          if
+            exit 0
+          fi
       - name: Check Lock File
         run: |
           diff ${LOCK_FILE} ${LOCK_FILE}.bak

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,13 @@ jobs:
             exit 1
           else
             echo "Expected, this example should fail"
-            exit 0
+          fi
+
+          if [ -f "/tmp/sqlness-bad-example.lock" ]; then
+            echo "Lock file should be deleted after run."
+            exit 1
+          else
+            echo "Expected, lock file is deleted."
           fi
       - name: Check Lock File
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,18 @@ jobs:
         run: |
           make test
           echo "Checking if ${LOCK_FILE} has changed..."
-      - name: Run examples
+      - name: Run basic example
         run: |
           make basic-example
+      - name: Run bad example
+        run: |
+          if make bad-example; then
+            echo "Cannot reach here, this example should fail"
+            exit 1;
+          else
+            echo "Expected, this example should fail"
+            exit 0;
+          if
       - name: Check Lock File
         run: |
           diff ${LOCK_FILE} ${LOCK_FILE}.bak

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
+# Ignore this output file, since the bad example will always fail.
+# For normal case, output file should not be ignored, and it acts as
+# a signal that our testcase need to be fixed.
 examples/bad-case/simple/select.output

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+examples/bad-case/simple/select.output

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,7 @@ clippy:
 	cd $(DIR); cargo clippy --all-targets --all-features --workspace -- -D warnings
 
 basic-example:
-	cd $(DIR); cargo run --example basic -- examples/basic.toml
+	cd $(DIR); cargo run --example basic
+
+bad-example:
+	cd $(DIR); cargo run --example bad

--- a/README.md
+++ b/README.md
@@ -23,13 +23,12 @@ examples/
 │       ├── select.result    # Expected result file
 │       └── select.sql       # Input SQL testcase
 ├── basic.rs                 # Entrypoint of this example
-└── basic.toml               # Config of this example
 
 ```
 
 When run it via
 ```bash
-cargo run --example basic -- examples/basic.toml
+cargo run --example basic
 ```
 It will do following things:
 1. Collect all environments(first-level directory) under `basic-case`.

--- a/examples/bad-case/simple/select.result
+++ b/examples/bad-case/simple/select.result
@@ -1,0 +1,7 @@
+SELECT
+    *
+FROM
+    `table`;
+
+ok
+

--- a/examples/bad-case/simple/select.sql
+++ b/examples/bad-case/simple/select.sql
@@ -1,0 +1,4 @@
+SELECT
+    *
+FROM
+    `table`;

--- a/examples/bad.rs
+++ b/examples/bad.rs
@@ -5,7 +5,7 @@
 //! When there is any diff between ${testcase}.output and ${testcase}.result,
 //! Users must resolve the diff, and keep the result file up to date.
 
-use std::{fmt::Display, path::Path};
+use std::{fmt::Display, fs::File, path::Path};
 
 use async_trait::async_trait;
 use sqlness::{ConfigBuilder, Database, EnvController, Runner};
@@ -20,12 +20,18 @@ impl Database for MyDB {
     }
 }
 
+// Used as a flag to indicate MyDB has started
+const LOCK_FILE: &str = "/tmp/sqlness-bad-example.lock";
+
 impl MyDB {
     fn new(_env: &str, _config: Option<&Path>) -> Self {
+        File::create(LOCK_FILE).unwrap();
         MyDB
     }
 
-    fn stop(self) {}
+    fn stop(self) {
+        std::fs::remove_file(LOCK_FILE).unwrap();
+    }
 }
 
 #[async_trait]

--- a/examples/bad.rs
+++ b/examples/bad.rs
@@ -1,5 +1,10 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+//! A demo designed to run failed.
+//!
+//! When there is any diff between ${testcase}.output and ${testcase}.result,
+//! Users must resolve the diff, and keep the result file up to date.
+
 use std::{fmt::Display, path::Path};
 
 use async_trait::async_trait;
@@ -11,9 +16,7 @@ struct MyDB;
 #[async_trait]
 impl Database for MyDB {
     async fn query(&self, _query: String) -> Box<dyn Display> {
-        // Implement query logic here
-        // println!("Exec {}...", query);
-        return Box::new("ok".to_string());
+        return Box::new("Unexpected".to_string());
     }
 }
 
@@ -22,9 +25,7 @@ impl MyDB {
         MyDB
     }
 
-    fn stop(self) {
-        println!("MyDB stopped.");
-    }
+    fn stop(self) {}
 }
 
 #[async_trait]
@@ -32,12 +33,10 @@ impl EnvController for MyController {
     type DB = MyDB;
 
     async fn start(&self, env: &str, config: Option<&Path>) -> Self::DB {
-        println!("Start, env:{}, config:{:?}.", env, config);
         MyDB::new(env, config)
     }
 
-    async fn stop(&self, env: &str, database: Self::DB) {
-        println!("Stop, env:{}.", env,);
+    async fn stop(&self, _env: &str, database: Self::DB) {
         database.stop();
     }
 }
@@ -46,7 +45,7 @@ impl EnvController for MyController {
 async fn main() {
     let env = MyController;
     let config = ConfigBuilder::default()
-        .case_dir("examples/basic-case".to_string())
+        .case_dir("examples/bad-case".to_string())
         .build()
         .unwrap();
     let runner = Runner::new_with_config(config, env)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -78,8 +78,11 @@ impl<E: EnvController> Runner<E> {
             };
             let db = self.env_controller.start(&env, config_path).await;
             if let Err(e) = self.run_env(&env, &db).await {
-                println!("Environment {} run failed with error {:?}", env, e);
+                println!("Environment {} run failed, error:{:?}.", env, e);
+                self.env_controller.stop(&env, db).await;
+                return Err(e);
             }
+
             self.env_controller.stop(&env, db).await;
         }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,7 +2,6 @@
 
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 
 use prettydiff::basic::DiffOp;
 use prettydiff::diff_lines;
@@ -32,11 +31,11 @@ use crate::{config::Config, environment::EnvController};
 /// For more detailed explaination, refer to crate level documentment.
 pub struct Runner<E: EnvController> {
     config: Config,
-    env_controller: Arc<E>,
+    env_controller: E,
 }
 
 impl<E: EnvController> Runner<E> {
-    pub async fn try_new<P: AsRef<Path>>(config_path: P, env: E) -> Result<Self> {
+    pub async fn try_new<P: AsRef<Path>>(config_path: P, env_controller: E) -> Result<Self> {
         let mut config_file =
             File::open(config_path.as_ref())
                 .await
@@ -55,14 +54,14 @@ impl<E: EnvController> Runner<E> {
 
         Ok(Self {
             config,
-            env_controller: Arc::new(env),
+            env_controller,
         })
     }
 
-    pub async fn new_with_config(config: Config, env: E) -> Result<Self> {
+    pub async fn new_with_config(config: Config, env_controller: E) -> Result<Self> {
         Ok(Self {
             config,
-            env_controller: Arc::new(env),
+            env_controller,
         })
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #16

# Rationale for this change
 
When one env run failed, its error will be ignored, which is not what we expect.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Return error out when a env run failed
- Add a bad example to test this.
  - It will also write a file lock as liveness flag, CI will ensure it's got deleted after running
-  Remove some unnecessary code.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

New bad example
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

