### PR TITLE
feat: mutable borrow `Database`'s implementor

### DIFF
--- a/examples/bad.rs
+++ b/examples/bad.rs
@@ -5,6 +5,8 @@
 //! When there is any diff between ${testcase}.output and ${testcase}.result,
 //! Users must resolve the diff, and keep the result file up to date.
 
+#![allow(clippy::print_stdout)]
+
 use std::{fmt::Display, fs::File, path::Path};
 
 use async_trait::async_trait;
@@ -15,7 +17,7 @@ struct MyDB;
 
 #[async_trait]
 impl Database for MyDB {
-    async fn query(&self, _query: String) -> Box<dyn Display> {
+    async fn query(&mut self, _query: String) -> Box<dyn Display> {
         return Box::new("Unexpected".to_string());
     }
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,7 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+#![allow(clippy::print_stdout)]
+
 use std::{fmt::Display, path::Path};
 
 use async_trait::async_trait;
@@ -10,7 +12,7 @@ struct MyDB;
 
 #[async_trait]
 impl Database for MyDB {
-    async fn query(&self, _query: String) -> Box<dyn Display> {
+    async fn query(&mut self, _query: String) -> Box<dyn Display> {
         // Implement query logic here
         // println!("Exec {}...", query);
         return Box::new("ok".to_string());

--- a/src/case.rs
+++ b/src/case.rs
@@ -58,7 +58,7 @@ impl TestCase {
         })
     }
 
-    pub(crate) async fn execute<W>(&self, db: &dyn Database, writer: &mut W) -> Result<()>
+    pub(crate) async fn execute<W>(&self, db: &mut dyn Database, writer: &mut W) -> Result<()>
     where
         W: AsyncWrite + Unpin,
     {
@@ -91,7 +91,7 @@ impl Query {
         self.query_lines.push(line.to_string());
     }
 
-    async fn execute<W>(&self, db: &dyn Database, writer: &mut W) -> Result<()>
+    async fn execute<W>(&self, db: &mut dyn Database, writer: &mut W) -> Result<()>
     where
         W: AsyncWrite + Unpin,
     {

--- a/src/database.rs
+++ b/src/database.rs
@@ -13,5 +13,5 @@ use async_trait::async_trait;
 /// [`EnvController::start`]: crate::EnvController#tymethod.start
 #[async_trait]
 pub trait Database {
-    async fn query(&self, query: String) -> Box<dyn Display>;
+    async fn query(&mut self, query: String) -> Box<dyn Display>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 //! both `sqlness/local/dml/basic.sql` and `sqlness/local/dml/another-dir/basic.sql`
 //! will be run under the `local` in the same pass.
 
+#![allow(clippy::print_stdout)]
+
 mod case;
 mod config;
 mod database;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -76,8 +76,8 @@ impl<E: EnvController> Runner<E> {
             } else {
                 None
             };
-            let db = self.env_controller.start(&env, config_path).await;
-            let run_result = self.run_env(&env, &db).await;
+            let mut db = self.env_controller.start(&env, config_path).await;
+            let run_result = self.run_env(&env, &mut db).await;
             self.env_controller.stop(&env, db).await;
 
             if let Err(e) = run_result {
@@ -122,7 +122,7 @@ impl<E: EnvController> Runner<E> {
         Ok(result)
     }
 
-    async fn run_env(&self, env: &str, db: &E::DB) -> Result<()> {
+    async fn run_env(&self, env: &str, db: &mut E::DB) -> Result<()> {
         let case_paths = self.collect_case_paths(env).await?;
         let mut diff_cases = vec![];
         let mut errors = vec![];
@@ -169,7 +169,7 @@ impl<E: EnvController> Runner<E> {
         }
     }
 
-    async fn run_single_case(&self, db: &E::DB, path: &PathBuf) -> Result<bool> {
+    async fn run_single_case(&self, db: &mut E::DB, path: &PathBuf) -> Result<bool> {
         let case_path = path.with_extension(&self.config.test_case_extension);
         let case = TestCase::from_file(case_path, &self.config).await?;
         let output_path = path.with_extension(&self.config.output_result_extension);


### PR DESCRIPTION
... so that we can change its internal state.

# Which issue does this PR close?

Closes #

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

We need to impl `Database` like this:

```rust
struct Foo {
  s: String,
}

impl Database for Foo {
  async fn query(&self, query: String) -> Box<dyn Display> {
    if query == "blah" {
      self.s = "x"; // has to mutable borrow `self` to make this happened
    }
    ...
  }
}
```

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

- make `Database` mutable borrowed in its method `query`
- also make clippy happy

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

yes, implementors need to change their methods names

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
