### PR TITLE
feat: follow symbolic link to search test case files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,11 @@ pub struct Config {
     #[builder(default = "Config::default_test_filter()")]
     #[serde(default = "Config::default_test_filter")]
     pub test_filter: String,
+    /// Whether follow symbolic links when searching test case files.
+    /// Defaults to "false" (not follow symbolic links).
+    #[builder(default = "false")]
+    #[serde(default = "Config::default_follow_links")]
+    pub follow_links: bool,
 }
 
 impl Config {
@@ -58,5 +63,9 @@ impl Config {
 
     fn default_test_filter() -> String {
         "".to_string()
+    }
+
+    fn default_follow_links() -> bool {
+        false
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -220,6 +220,7 @@ impl<E: EnvController> Runner<E> {
 
         let test_case_extension = self.config.test_case_extension.as_str();
         let mut cases: Vec<_> = WalkDir::new(&root)
+            .follow_links(self.config.follow_links)
             .into_iter()
             .filter_map(|entry| {
                 entry


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Some test case files can be shared between env. Use symbolic links could avoid copying these files. `walkdir` crate already provides this flag when traverse the directory, we can just simply make it a config option to let users enable it. The default behavior is not follow symbolic links.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

Expose a "follow links" config option.

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

no

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
