### PR TITLE
feat: define interceptor and implement arg interceptor

### DIFF
--- a/examples/bad.rs
+++ b/examples/bad.rs
@@ -8,14 +8,14 @@
 use std::{fmt::Display, fs::File, path::Path};
 
 use async_trait::async_trait;
-use sqlness::{ConfigBuilder, Database, EnvController, Runner};
+use sqlness::{ConfigBuilder, Database, EnvController, QueryContext, Runner};
 
 struct MyController;
 struct MyDB;
 
 #[async_trait]
 impl Database for MyDB {
-    async fn query(&self, _query: String) -> Box<dyn Display> {
+    async fn query(&self, _ctx: QueryContext, _query: String) -> Box<dyn Display> {
         return Box::new("Unexpected".to_string());
     }
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,14 +3,14 @@
 use std::{fmt::Display, path::Path};
 
 use async_trait::async_trait;
-use sqlness::{ConfigBuilder, Database, EnvController, Runner};
+use sqlness::{ConfigBuilder, Database, EnvController, QueryContext, Runner};
 
 struct MyController;
 struct MyDB;
 
 #[async_trait]
 impl Database for MyDB {
-    async fn query(&self, _query: String) -> Box<dyn Display> {
+    async fn query(&self, _context: QueryContext, _query: String) -> Box<dyn Display> {
         // Implement query logic here
         // println!("Exec {}...", query);
         return Box::new("ok".to_string());

--- a/examples/interceptor-arg/simple/input.result
+++ b/examples/interceptor-arg/simple/input.result
@@ -1,0 +1,15 @@
+-- SQLNESS ARG bla=a addr=127.0.0.1 port=3306
+SELECT * FROM t;
+
+addr=127.0.0.1
+bla=a
+port=3306
+
+-- SQLNESS 🤪ARG🤪 addr=127.0.0.1 port=3306
+-- SQLNESS   ARG port=3307
+SELECT * 
+FROM t
+WHERE A=B;
+
+port=3307
+

--- a/examples/interceptor-arg/simple/input.sql
+++ b/examples/interceptor-arg/simple/input.sql
@@ -1,0 +1,8 @@
+-- SQLNESS ARG bla=a addr=127.0.0.1 port=3306
+SELECT * FROM t;
+
+-- SQLNESS 🤪ARG🤪 addr=127.0.0.1 port=3306
+-- SQLNESS   ARG port=3307
+SELECT * 
+FROM t
+WHERE A=B;

--- a/examples/interceptor_arg.rs
+++ b/examples/interceptor_arg.rs
@@ -2,7 +2,7 @@
 
 //! Shows how an ARG interceptor works.
 
-use std::{fmt::Display, fs::File, path::Path};
+use std::{fmt::Display, path::Path};
 
 use async_trait::async_trait;
 use sqlness::{ConfigBuilder, Database, EnvController, QueryContext, Runner};
@@ -24,18 +24,12 @@ impl Database for MyDB {
     }
 }
 
-// Used as a flag to indicate MyDB has started
-const LOCK_FILE: &str = "/tmp/sqlness-interceptor-arg-example.lock";
-
 impl MyDB {
     fn new(_env: &str, _config: Option<&Path>) -> Self {
-        File::create(LOCK_FILE).unwrap();
         MyDB
     }
 
-    fn stop(self) {
-        std::fs::remove_file(LOCK_FILE).unwrap();
-    }
+    fn stop(self) {}
 }
 
 #[async_trait]

--- a/examples/interceptor_arg.rs
+++ b/examples/interceptor_arg.rs
@@ -1,0 +1,69 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! Shows how an ARG interceptor works.
+
+use std::{fmt::Display, fs::File, path::Path};
+
+use async_trait::async_trait;
+use sqlness::{ConfigBuilder, Database, EnvController, QueryContext, Runner};
+
+struct MyController;
+struct MyDB;
+
+#[async_trait]
+impl Database for MyDB {
+    async fn query(&self, ctx: QueryContext, _query: String) -> Box<dyn Display> {
+        println!("Exec query with context: {:#?}", ctx);
+        let mut args = ctx.context.into_iter().collect::<Vec<_>>();
+        args.sort();
+        let result = args
+            .into_iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Box::new(result);
+    }
+}
+
+// Used as a flag to indicate MyDB has started
+const LOCK_FILE: &str = "/tmp/sqlness-interceptor-arg-example.lock";
+
+impl MyDB {
+    fn new(_env: &str, _config: Option<&Path>) -> Self {
+        File::create(LOCK_FILE).unwrap();
+        MyDB
+    }
+
+    fn stop(self) {
+        std::fs::remove_file(LOCK_FILE).unwrap();
+    }
+}
+
+#[async_trait]
+impl EnvController for MyController {
+    type DB = MyDB;
+
+    async fn start(&self, env: &str, config: Option<&Path>) -> Self::DB {
+        MyDB::new(env, config)
+    }
+
+    async fn stop(&self, _env: &str, database: Self::DB) {
+        database.stop();
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let env = MyController;
+    let config = ConfigBuilder::default()
+        .case_dir("examples/interceptor-arg".to_string())
+        .build()
+        .unwrap();
+    let runner = Runner::new_with_config(config, env)
+        .await
+        .expect("Create Runner failed");
+
+    println!("Run testcase...");
+
+    runner.run().await.unwrap();
+}

--- a/examples/interceptor_arg.rs
+++ b/examples/interceptor_arg.rs
@@ -13,12 +13,11 @@ struct MyDB;
 #[async_trait]
 impl Database for MyDB {
     async fn query(&self, ctx: QueryContext, _query: String) -> Box<dyn Display> {
-        println!("Exec query with context: {:#?}", ctx);
         let mut args = ctx.context.into_iter().collect::<Vec<_>>();
         args.sort();
         let result = args
             .into_iter()
-            .map(|(k, v)| format!("{}={}", k, v))
+            .map(|(k, v)| format!("{k}={v}"))
             .collect::<Vec<_>>()
             .join("\n");
         return Box::new(result);

--- a/src/case.rs
+++ b/src/case.rs
@@ -41,7 +41,7 @@ impl TestCase {
         while let Some(line) = lines.next_line().await? {
             // intercept command start with INTERCEPTOR_PREFIX
             if line.starts_with(&cfg.interceptor_prefix) {
-                query.push_interceptor(&cfg, line);
+                query.push_interceptor(cfg, line);
                 continue;
             }
 

--- a/src/case.rs
+++ b/src/case.rs
@@ -41,7 +41,7 @@ impl TestCase {
         while let Some(line) = lines.next_line().await? {
             // intercept command start with INTERCEPTOR_PREFIX
             if line.starts_with(&cfg.interceptor_prefix) {
-                query.push_interceptor(cfg, line);
+                query.push_interceptor(&cfg.interceptor_prefix, line);
                 continue;
             }
 
@@ -107,9 +107,9 @@ impl Query {
         }
     }
 
-    fn push_interceptor(&mut self, cfg: &Config, interceptor_line: String) {
+    fn push_interceptor(&mut self, interceptor_prefix: &str, interceptor_line: String) {
         let interceptor_text = interceptor_line
-            .trim_start_matches(&cfg.interceptor_prefix)
+            .trim_start_matches(interceptor_prefix)
             .trim_start();
         for factories in &self.interceptor_factories {
             if let Some(interceptor) = factories.try_new(interceptor_text) {

--- a/src/case.rs
+++ b/src/case.rs
@@ -35,7 +35,7 @@ impl TestCase {
             })?;
 
         let mut queries = vec![];
-        let mut query = Query::default();
+        let mut query = Query::with_interceptor_factories(interceptor_factories.clone());
 
         let mut lines = BufReader::new(file).lines();
         while let Some(line) = lines.next_line().await? {
@@ -88,7 +88,7 @@ impl Display for TestCase {
 /// A String-to-String map used as query context.
 #[derive(Default, Debug)]
 pub struct QueryContext {
-    pub(crate) context: HashMap<String, String>,
+    pub context: HashMap<String, String>,
 }
 
 #[derive(Default)]
@@ -169,6 +169,7 @@ impl Query {
     {
         for interceptor in &self.interceptor_lines {
             writer.write_all(interceptor.as_bytes()).await?;
+            writer.write("\n".as_bytes()).await?;
         }
         for line in &self.query_lines {
             writer.write_all(line.as_bytes()).await?;

--- a/src/database.rs
+++ b/src/database.rs
@@ -4,14 +4,17 @@ use std::fmt::Display;
 
 use async_trait::async_trait;
 
+use crate::case::QueryContext;
+
 /// Query executor.
 ///
 /// [`Runner`] will call [`EnvController::start`] to create database to
-/// execute query.
+/// execute query. The context parameter is a key-value pair map that
+/// usually comes from interceptor or config file.
 ///
 /// [`Runner`]: crate::Runner
 /// [`EnvController::start`]: crate::EnvController#tymethod.start
 #[async_trait]
 pub trait Database {
-    async fn query(&self, query: String) -> Box<dyn Display>;
+    async fn query(&self, context: QueryContext, query: String) -> Box<dyn Display>;
 }

--- a/src/database_impl/mysql.rs
+++ b/src/database_impl/mysql.rs
@@ -10,7 +10,7 @@ use std::{
 use async_trait::async_trait;
 use mysql::{prelude::Queryable, Conn, OptsBuilder, Row};
 
-use crate::{config::DatabaseConnConfig, database::DatabaseBuilder, Database};
+use crate::{config::DatabaseConnConfig, database::DatabaseBuilder, Database, QueryContext};
 
 #[derive(Default)]
 pub struct MysqlBuilder;
@@ -73,7 +73,7 @@ impl DatabaseBuilder for MysqlBuilder {
 
 #[async_trait]
 impl Database for MysqlDatabase {
-    async fn query(&self, query: String) -> Box<dyn Display> {
+    async fn query(&self, _: QueryContext, query: String) -> Box<dyn Display> {
         Self::execute(&query, Arc::clone(&self.conn)).await
     }
 }

--- a/src/interceptor.rs
+++ b/src/interceptor.rs
@@ -1,0 +1,25 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! Query interceptor implementations.
+
+use std::sync::Arc;
+
+use crate::case::QueryContext;
+
+pub mod arg;
+
+pub type InterceptorRef = Box<dyn Interceptor>;
+
+pub trait Interceptor {
+    #[allow(unused_variables)]
+    fn before_execute(&self, query: &mut Vec<String>, context: &mut QueryContext) {}
+
+    #[allow(unused_variables)]
+    fn after_execute(&self, result: &mut String) {}
+}
+
+pub type InterceptorFactoryRef = Arc<dyn InterceptorFactory>;
+
+pub trait InterceptorFactory {
+    fn try_new(&self, interceptor: &str) -> Option<InterceptorRef>;
+}

--- a/src/interceptor/arg.rs
+++ b/src/interceptor/arg.rs
@@ -37,8 +37,9 @@ pub struct ArgInterceptorFactory;
 
 impl InterceptorFactory for ArgInterceptorFactory {
     fn try_new(&self, interceptor: &str) -> Option<InterceptorRef> {
-        if interceptor.contains(PREFIX) {
-            let args = Self::separate_key_value_pairs(interceptor);
+        if interceptor.starts_with(PREFIX) {
+            let args =
+                Self::separate_key_value_pairs(interceptor.trim_start_matches(PREFIX).trim_start());
             Some(Box::new(ArgInterceptor { args }))
         } else {
             None

--- a/src/interceptor/arg.rs
+++ b/src/interceptor/arg.rs
@@ -1,0 +1,79 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use crate::case::QueryContext;
+
+use super::{Interceptor, InterceptorFactory, InterceptorRef};
+
+const PREFIX: &str = "ARG";
+
+/// Pass arguments to the [QueryContext].
+///
+/// # Example
+/// ``` sql
+/// -- SQLNESS ARG arg1=value1 arg2=value2
+/// SELECT * FROM t;
+/// ```
+///
+/// # Format
+/// The arguments are in the format of `key=value`, without space. The key should not contains
+/// equal marker (`=`), and value can be any string without space. The arguments are separated
+/// by spaces.
+///
+/// It will overwrite existing key-value pair in context if the key name is same.
+#[derive(Debug)]
+pub struct ArgInterceptor {
+    args: Vec<(String, String)>,
+}
+
+impl Interceptor for ArgInterceptor {
+    fn before_execute(&self, _: &mut Vec<String>, context: &mut QueryContext) {
+        for (key, value) in &self.args {
+            context.context.insert(key.to_string(), value.to_string());
+        }
+    }
+}
+
+pub struct ArgInterceptorFactory;
+
+impl InterceptorFactory for ArgInterceptorFactory {
+    fn try_new(&self, interceptor: &str) -> Option<InterceptorRef> {
+        if interceptor.contains(PREFIX) {
+            let args = Self::separate_key_value_pairs(interceptor);
+            Some(Box::new(ArgInterceptor { args }))
+        } else {
+            None
+        }
+    }
+}
+
+impl ArgInterceptorFactory {
+    fn separate_key_value_pairs(input: &str) -> Vec<(String, String)> {
+        let mut result = Vec::new();
+        for pair in input.split(' ') {
+            if let Some((key, value)) = pair.split_once('=') {
+                result.push((key.to_string(), value.to_string()));
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cut_arg_string() {
+        let input = "ARG arg1=value1 arg2=value2 arg3=a=b=c arg4= arg5=,,,";
+        let expected = vec![
+            ("arg1".to_string(), "value1".to_string()),
+            ("arg2".to_string(), "value2".to_string()),
+            ("arg3".to_string(), "a=b=c".to_string()),
+            ("arg4".to_string(), "".to_string()),
+            ("arg5".to_string(), ",,,".to_string()),
+        ];
+
+        let args = ArgInterceptorFactory::separate_key_value_pairs(input);
+        assert_eq!(args, expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,10 @@ mod config;
 mod database;
 mod environment;
 mod error;
+mod interceptor;
 mod runner;
 
+pub use case::QueryContext;
 pub use config::{Config, ConfigBuilder};
 pub use database::Database;
 pub use environment::EnvController;


### PR DESCRIPTION
# Which issue does this PR close?

Part of #34 

# Rationale for this change
 
Define interceptor-related traits, and implement an `ARG` interceptor that is useful to parse query context to DB runner.

# What changes are included in this PR?

- interceptor traits
  - `Interceptor`
  - `InterceptorFactory`
- interceptor implementation
  - `ArgInterceptor`
  - `ArgInterceptorFactory`
- example

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

Yes, the `Database` trait adds a new parameter `QueryContext` which is a string-to-string key value map.
```
#[async_trait]
pub trait Database {
    async fn query(&self, context: QueryContext, query: String) -> Box<dyn Display>;
}
```

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

new example `interceptor_arg` and unit test
