### PR TITLE
refactor: add interceptor to configs

### DIFF
--- a/sqlness-cli/src/main.rs
+++ b/sqlness-cli/src/main.rs
@@ -84,7 +84,7 @@ fn main() {
         .expect("build config");
 
     block_on(async {
-        let runner = Runner::try_new(config, ctrl).await.expect("build runner");
+        let runner = Runner::new(config, ctrl);
 
         runner.run().await.expect("run testcase")
     });

--- a/sqlness-cli/src/main.rs
+++ b/sqlness-cli/src/main.rs
@@ -84,9 +84,7 @@ fn main() {
         .expect("build config");
 
     block_on(async {
-        let runner = Runner::new_with_config(config, ctrl)
-            .await
-            .expect("build runner");
+        let runner = Runner::try_new(config, ctrl).await.expect("build runner");
 
         runner.run().await.expect("run testcase")
     });

--- a/sqlness/examples/bad.rs
+++ b/sqlness/examples/bad.rs
@@ -54,7 +54,7 @@ async fn main() {
         .case_dir("examples/bad-case".to_string())
         .build()
         .unwrap();
-    let runner = Runner::new_with_config(config, env)
+    let runner = Runner::try_new(config, env)
         .await
         .expect("Create Runner failed");
 

--- a/sqlness/examples/bad.rs
+++ b/sqlness/examples/bad.rs
@@ -54,9 +54,7 @@ async fn main() {
         .case_dir("examples/bad-case".to_string())
         .build()
         .unwrap();
-    let runner = Runner::try_new(config, env)
-        .await
-        .expect("Create Runner failed");
+    let runner = Runner::new(config, env);
 
     println!("Run testcase...");
 

--- a/sqlness/examples/basic.rs
+++ b/sqlness/examples/basic.rs
@@ -49,7 +49,7 @@ async fn main() {
         .case_dir("examples/basic-case".to_string())
         .build()
         .unwrap();
-    let runner = Runner::new_with_config(config, env)
+    let runner = Runner::try_new(config, env)
         .await
         .expect("Create Runner failed");
 

--- a/sqlness/examples/basic.rs
+++ b/sqlness/examples/basic.rs
@@ -49,9 +49,7 @@ async fn main() {
         .case_dir("examples/basic-case".to_string())
         .build()
         .unwrap();
-    let runner = Runner::try_new(config, env)
-        .await
-        .expect("Create Runner failed");
+    let runner = Runner::new(config, env);
 
     println!("Run testcase...");
 

--- a/sqlness/examples/interceptor_arg.rs
+++ b/sqlness/examples/interceptor_arg.rs
@@ -5,7 +5,7 @@
 use std::{fmt::Display, path::Path};
 
 use async_trait::async_trait;
-use sqlness::{ConfigBuilder, Database, EnvController, QueryContext, Runner};
+use sqlness::{builtin_interceptors, ConfigBuilder, Database, EnvController, QueryContext, Runner};
 
 struct MyController;
 struct MyDB;
@@ -50,9 +50,10 @@ async fn main() {
     let env = MyController;
     let config = ConfigBuilder::default()
         .case_dir("examples/interceptor-arg".to_string())
+        .interceptor_factories(builtin_interceptors())
         .build()
         .unwrap();
-    let runner = Runner::new_with_config(config, env)
+    let runner = Runner::try_new(config, env)
         .await
         .expect("Create Runner failed");
 

--- a/sqlness/examples/interceptor_arg.rs
+++ b/sqlness/examples/interceptor_arg.rs
@@ -53,9 +53,7 @@ async fn main() {
         .interceptor_factories(builtin_interceptors())
         .build()
         .unwrap();
-    let runner = Runner::try_new(config, env)
-        .await
-        .expect("Create Runner failed");
+    let runner = Runner::new(config, env);
 
     println!("Run testcase...");
 

--- a/sqlness/src/case.rs
+++ b/sqlness/src/case.rs
@@ -23,18 +23,14 @@ pub(crate) struct TestCase {
 }
 
 impl TestCase {
-    pub(crate) fn from_file<P: AsRef<Path>>(
-        path: P,
-        cfg: &Config,
-        interceptor_factories: Vec<InterceptorFactoryRef>,
-    ) -> Result<Self> {
+    pub(crate) fn from_file<P: AsRef<Path>>(path: P, cfg: &Config) -> Result<Self> {
         let file = File::open(path.as_ref()).map_err(|e| SqlnessError::ReadPath {
             source: e,
             path: path.as_ref().to_path_buf(),
         })?;
 
         let mut queries = vec![];
-        let mut query = Query::with_interceptor_factories(interceptor_factories.clone());
+        let mut query = Query::with_interceptor_factories(cfg.interceptor_factories.clone());
 
         let reader = BufReader::new(file);
         for line in reader.lines() {
@@ -55,7 +51,7 @@ impl TestCase {
             // SQL statement ends with ';'
             if line.ends_with(';') {
                 queries.push(query);
-                query = Query::with_interceptor_factories(interceptor_factories.clone());
+                query = Query::with_interceptor_factories(cfg.interceptor_factories.clone());
             } else {
                 query.append_query_line("\n");
             }

--- a/sqlness/src/config.rs
+++ b/sqlness/src/config.rs
@@ -1,48 +1,45 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use derive_builder::Builder;
-use serde::{Deserialize, Serialize};
+
+use crate::interceptor::InterceptorFactoryRef;
 
 /// Configurations of [`Runner`].
 ///
 /// [`Runner`]: crate::Runner
-#[derive(Debug, Serialize, Deserialize, Builder)]
+#[derive(Builder)]
 pub struct Config {
     pub case_dir: String,
     /// Default value: `sql`
     #[builder(default = "Config::default_test_case_extension()")]
-    #[serde(default = "Config::default_test_case_extension")]
     pub test_case_extension: String,
     /// Default value: `result`
     #[builder(default = "Config::default_result_extension()")]
-    #[serde(default = "Config::default_result_extension")]
     pub result_extension: String,
     /// Default value: `-- SQLNESS`
     #[builder(default = "Config::default_interceptor_prefix()")]
-    #[serde(default = "Config::default_interceptor_prefix")]
     pub interceptor_prefix: String,
     /// Default value: `config.toml`
     #[builder(default = "Config::default_env_config_file()")]
-    #[serde(default = "Config::default_env_config_file")]
     pub env_config_file: String,
     /// Fail this run as soon as one case fails if true
-    #[builder(default = "true")]
-    #[serde(default = "Config::default_fail_fast")]
+    #[builder(default = "Config::default_fail_fast()")]
     pub fail_fast: bool,
     /// Test only matched testcases, default `.*`
     /// Env is prepended before filename, eg `{env}:{filename}`
     #[builder(default = "Config::default_test_filter()")]
-    #[serde(default = "Config::default_test_filter")]
     pub test_filter: String,
     /// Test only matched env, default `.*`
     #[builder(default = "Config::default_env_filter()")]
-    #[serde(default = "Config::default_env_filter")]
     pub env_filter: String,
     /// Whether follow symbolic links when searching test case files.
     /// Defaults to "true" (follow symbolic links).
-    #[builder(default = "true")]
-    #[serde(default = "Config::default_follow_links")]
+    #[builder(default = "Config::default_follow_links()")]
     pub follow_links: bool,
+
+    /// Interceptors used to pre-process input query and post-process query response
+    #[builder(default = "Config::default_interceptors()")]
+    pub interceptor_factories: Vec<InterceptorFactoryRef>,
 }
 
 impl Config {
@@ -76,6 +73,10 @@ impl Config {
 
     fn default_follow_links() -> bool {
         true
+    }
+
+    fn default_interceptors() -> Vec<InterceptorFactoryRef> {
+        vec![]
     }
 }
 

--- a/sqlness/src/lib.rs
+++ b/sqlness/src/lib.rs
@@ -68,4 +68,4 @@ pub use config::{Config, ConfigBuilder, DatabaseConfig, DatabaseConfigBuilder};
 pub use database::Database;
 pub use environment::EnvController;
 pub use error::SqlnessError;
-pub use runner::Runner;
+pub use runner::{builtin_interceptors, Runner};

--- a/sqlness/src/runner.rs
+++ b/sqlness/src/runner.rs
@@ -39,11 +39,11 @@ pub struct Runner<E: EnvController> {
 }
 
 impl<E: EnvController> Runner<E> {
-    pub async fn try_new(config: Config, env_controller: E) -> Result<Self> {
-        Ok(Self {
+    pub fn new(config: Config, env_controller: E) -> Self {
+        Self {
             config,
             env_controller,
-        })
+        }
     }
 
     pub async fn run(&self) -> Result<()> {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
Currently interceptors are hard-code, expose an option to let users configure it.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

1. Remove serde support for `Config`
2. Remove default_interceptor when build Runner, users need to configure it explicitly.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

1. Runner is built with `new` method.
2. No default interceptors are installed when build Runner
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
CI 
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

