### PR TITLE
chore: remove serde as direct dependency

### DIFF
--- a/sqlness/Cargo.toml
+++ b/sqlness/Cargo.toml
@@ -13,9 +13,8 @@ readme = { workspace = true }
 async-trait = "0.1"
 derive_builder = "0.11"
 mysql = { version = "23.0.1", optional = true }
-prettydiff = "0.6.2"
+prettydiff = { version = "0.6.2", default_features = false }
 regex = "1.7.1"
-serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 toml = "0.5"
 walkdir = "2.3"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Clean unused dep 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Remove direct dependency on serde
```rs
 (main)$ cargo tree -i serde
serde v1.0.152
├── mysql v23.0.1
│   └── sqlness v0.4.3 (/Users/jiacai/code/misc/sqlness/sqlness)
│       └── sqlness-cli v0.4.3 (/Users/jiacai/code/misc/sqlness/sqlness-cli)
├── mysql_common v0.29.2
│   └── mysql v23.0.1 (*)
├── rust_decimal v1.28.1
│   └── mysql_common v0.29.2 (*)
├── serde_json v1.0.93
│   ├── mysql v23.0.1 (*)
│   └── mysql_common v0.29.2 (*)
└── toml v0.5.11
    └── sqlness v0.4.3 (/Users/jiacai/code/misc/sqlness/sqlness) (*)

```
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

CI
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

