### PR TITLE
feat: display comment on result file

### DIFF
--- a/sqlness-cli/tests/local/input.result
+++ b/sqlness-cli/tests/local/input.result
@@ -1,3 +1,4 @@
+-- https://dev.mysql.com/doc/refman/8.0/en/example-auto-increment.html
 DROP TABLE IF EXISTS animals;
 
 affected_rows: 0

--- a/sqlness/examples/interceptor-replace/simple/replace.result
+++ b/sqlness/examples/interceptor-replace/simple/replace.result
@@ -13,6 +13,7 @@ SELECT 0;
 
 SELECT 1;
 
+-- example of capture group replacement
 -- SQLNESS REPLACE (?P<y>\d{4})-(?P<m>\d{2})-(?P<d>\d{2}) $m/$d/$y
 2012-03-14, 2013-01-01 and 2014-07-05;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 

Query comment is also good for understanding the result. We should include it either

# What changes are included in this PR?


Display comment before query in the result file.

## Before:

input:
```sql
-- example of capture group replacement
-- SQLNESS REPLACE (?P<y>\d{4})-(?P<m>\d{2})-(?P<d>\d{2}) $m/$d/$y
2012-03-14, 2013-01-01 and 2014-07-05;
```

result:
```sql
-- SQLNESS REPLACE (?P<y>\d{4})-(?P<m>\d{2})-(?P<d>\d{2}) $m/$d/$y
2012-03-14, 2013-01-01 and 2014-07-05;

03/14/2012, 01/01/2013 and 07/05/2014;
```

## After

input:
```sql
-- example of capture group replacement
-- SQLNESS REPLACE (?P<y>\d{4})-(?P<m>\d{2})-(?P<d>\d{2}) $m/$d/$y
2012-03-14, 2013-01-01 and 2014-07-05;
```

result:
```sql
-- example of capture group replacement
-- SQLNESS REPLACE (?P<y>\d{4})-(?P<m>\d{2})-(?P<d>\d{2}) $m/$d/$y
2012-03-14, 2013-01-01 and 2014-07-05;

03/14/2012, 01/01/2013 and 07/05/2014;
```

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

I think this should be considered as breaking change

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

existing examples
